### PR TITLE
* Allow set max tasks per offer which sets a limit on number of tasks

### DIFF
--- a/requests.go
+++ b/requests.go
@@ -116,6 +116,7 @@ type ServiceRequest interface {
 	SetInstances(int64) ServiceRequest
 	SetSchedule(string) (ServiceRequest, error)
 	SetScheduleType(string) (ServiceRequest, error)
+	SetMaxTasksPerOffer(int) ServiceRequest
 	SetNumRetriesOnFailures(int64) ServiceRequest
 }
 
@@ -167,6 +168,13 @@ func (r *SingularityRequest) SetSchedule(s string) (ServiceRequest, error) {
 // and set shedule for this request.
 func (r *SingularityRequest) SetInstances(i int64) ServiceRequest {
 	r.Instances = i
+	return r
+}
+
+// SetMaxTasksPerOffer accepts a cron schedule format as string
+// and set shedule for this request.
+func (r *SingularityRequest) SetMaxTasksPerOffer(i int) ServiceRequest {
+	r.MaxTasksPerOffer = i
 	return r
 }
 

--- a/requests_test.go
+++ b/requests_test.go
@@ -240,10 +240,11 @@ func TestNewRunOnceSet(t *testing.T) {
 	var data = []struct {
 		expectedID        string
 		expectedType      string
+		instances         int64
 		expectedInstances int64
 	}{
-		{"test-id", "RUN_ONCE", 0},
-		{"test-id-2", "RUN_ONCE", 2},
+		{"test-id", "RUN_ONCE", 0, 0},
+		{"test-id-2", "RUN_ONCE", 2, 2},
 	}
 
 	for _, tt := range data {
@@ -255,7 +256,10 @@ func TestNewRunOnceSet(t *testing.T) {
 			t.Errorf("Got %v, expected %v", req.Instances, tt.expectedInstances)
 		}
 		if req.RequestType != tt.expectedType {
-			t.Errorf("Got %s, expected %s", req.RequestType, tt.expectedType)
+			t.Errorf("SetInstances(%v): expected %v, got %v",
+				tt.instances,
+				tt.expectedInstances,
+				req.Instances)
 		}
 	}
 }
@@ -286,6 +290,30 @@ func TestNewRequestScale(t *testing.T) {
 		t.Errorf("Got %v, expected %v ",
 			req.SingularityScaleRequest.Incremental,
 			expectedIncrement)
+	}
+}
+
+func TestSetMaxTasksPerOffer(t *testing.T) {
+	var data = []struct {
+		expectedID               string
+		expectedType             string
+		maxTasksPerOffer         int
+		expectedMaxTasksPerOffer int
+	}{
+		{"test-id", "SERVICE", 3, 3},
+		{"service-123", "SERVICE", 3, 3},
+	}
+	for _, tt := range data {
+		req := NewRequest(RUN_ONCE, tt.expectedID).SetMaxTasksPerOffer(tt.maxTasksPerOffer).Get()
+		if req.ID != tt.expectedID {
+			t.Errorf("Got %s, expected %s", req.ID, tt.expectedID)
+		}
+		if req.MaxTasksPerOffer != tt.expectedMaxTasksPerOffer {
+			t.Errorf("SetMaxTasksPerOffer(%v): expected %v, got %v",
+				tt.maxTasksPerOffer,
+				tt.expectedMaxTasksPerOffer,
+				req.MaxTasksPerOffer)
+		}
 	}
 }
 

--- a/struct.go
+++ b/struct.go
@@ -116,10 +116,19 @@ type DockerInfo struct {
 	ForcePullImage              bool                         `json:"forcePullImage,omitempty"`
 	SingularityDockerParameters []SingularityDockerParameter `json:"dockerParameters,omitEmpty"`
 	Privileged                  bool                         `json:"privileged,omitEmpty"`
-	Network                     string                       `json:"network,omitEmpty"`
-	//network	com.hubspot.mesos.SingularityDockerNetworkType	optional	Docker netowkr type. Value can be BRIDGE, HOST, or NONE
+	Network                     string                       `json:"network,omitEmpty"` //Value can be BRIDGE, HOST, or NONE
 	//portMappings	Array[SingularityDockerPortMapping]	optional	List of port mappings
-	Image string `json:"image"`
+	Image              string `json:"image"`
+	*DockerPortMapping `json:"portMappings,omitEmpty"`
+}
+
+//https://github.com/HubSpot/Singularity/blob/master/Docs/reference/api.md#model-SingularityDockerPortMapping
+type DockerPortMapping struct {
+	HostPort          int    `json:"hostPort"`
+	ContainerPort     int    `json:"containerPort"`
+	ContainerPortType string `json:"containerPortType,omitempty"` //Allowable values: LITERAL, FROM_OFFER
+	Protocol          string `json:"protocol,omitempty"`          //Default is tcp
+	HostPortType      string `json:"hostPortType,omitempty"`      //Allowable values: LITERAL, FROM_OFFER
 }
 
 // https://github.com/HubSpot/Singularity/blob/master/Docs/reference/api.md#model-SingularityDockerParameter


### PR DESCRIPTION
running on a slave. Default no limit, up to scheduler.
* Add portmapping for Docker deploy, instances where users want to
pin specific ports